### PR TITLE
Fix failing test for header

### DIFF
--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,8 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders the header', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const headerElement = screen.getByText(/weather guesser!/i);
+  expect(headerElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- update default CRA test to verify the app header

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683fadb0f0188329940619f35837fab0