### PR TITLE
Add onboarding walkthrough

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Footer from "./Footer";
 import NewCityAndOptions from "./components/NewCityAndOptions";
 import GuessForm from "./components/GuessForm";
 import MapAndOptions from "./components/MapAndOptions";
+import Onboarding from "./components/Onboarding";
 import { places } from "./modules/places";
 import FetchWrapper from "./modules/fetchwrapper";
 import Answer from "./components/Answer";
@@ -14,12 +15,20 @@ export default function App() {
   const [answer, setAnswer] = useState([0, ""]);
   const [weather, setWeather] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [showOnboarding, setShowOnboarding] = useState(false);
   const [options, setOptions] = useState({
     temp: 1, // 1 - f, 0 - c
     tempDisplay: "℉",
     region: 0, // 0 - Global, 1 - North America, 2 - Europe, 3 - Asia
     difficulty: 0, // 0 - Easy, 1 - Medium, 2 - Hard
   });
+
+  // Show onboarding for new visitors
+  useEffect(() => {
+    if (!localStorage.getItem("seenOnboarding")) {
+      setShowOnboarding(true);
+    }
+  }, []);
 
   // Load the first city on page load
   useEffect(() => {
@@ -99,6 +108,11 @@ export default function App() {
     }
   }
 
+  function handleOnboardingClose() {
+    localStorage.setItem("seenOnboarding", "true");
+    setShowOnboarding(false);
+  }
+
   // Fetch weather data for the current city and update the state based on user guess
   function handleAnswerSubmit(e) {
     e.preventDefault();
@@ -172,6 +186,9 @@ export default function App() {
 
   return (
     <>
+      {showOnboarding && (
+        <Onboarding onClose={handleOnboardingClose} />
+      )}
       <div className="App">
         <Header />
         <section id="main-content">

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -3,6 +3,6 @@ import App from './App';
 
 test('renders the header', () => {
   render(<App />);
-  const headerElement = screen.getByText(/weather guesser!/i);
-  expect(headerElement).toBeInTheDocument();
+  const headerElement = screen.getByRole('heading', { level: 1 });
+  expect(headerElement).toHaveTextContent(/weather guesser!/i);
 });

--- a/src/components/Onboarding.css
+++ b/src/components/Onboarding.css
@@ -4,12 +4,12 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  position: absolute;
+  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
   height: 100%;
-  z-index: 20;
+  z-index: 200;
   background-color: rgba(250, 250, 250, 0.9);
   border: 2px solid black;
 }

--- a/src/components/Onboarding.css
+++ b/src/components/Onboarding.css
@@ -1,0 +1,28 @@
+#onboarding-wrapper {
+  font-size: 0.8em;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 20;
+  background-color: rgba(250, 250, 250, 0.9);
+  border: 2px solid black;
+}
+
+#onboarding-box {
+  text-align: center;
+  padding: 20px;
+}
+
+#onboarding-close {
+  margin-top: 10px;
+}
+
+.hide {
+  display: none !important;
+}

--- a/src/components/Onboarding.css
+++ b/src/components/Onboarding.css
@@ -1,26 +1,36 @@
-#onboarding-wrapper {
-  font-size: 0.8em;
+#onboarding-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
   display: flex;
-  flex-direction: column;
   justify-content: center;
   align-items: center;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 200;
-  background-color: rgba(250, 250, 250, 0.9);
-  border: 2px solid black;
+  background-color: rgba(0, 0, 0, 0.6);
 }
 
-#onboarding-box {
+#onboarding-card {
+  background-color: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  padding: 30px 40px;
+  width: 90%;
+  max-width: 400px;
+  font-size: 1rem;
   text-align: center;
-  padding: 20px;
+}
+
+#onboarding-card h2 {
+  margin-top: 0;
+}
+
+#onboarding-card ol {
+  text-align: left;
+  margin: 20px 0;
+  padding-left: 20px;
 }
 
 #onboarding-close {
-  margin-top: 10px;
+  margin-top: 20px;
 }
 
 .hide {

--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -2,14 +2,20 @@ import "./Onboarding.css";
 
 export default function Onboarding({ onClose }) {
   return (
-    <div id="onboarding-wrapper">
-      <div id="onboarding-box">
-        <h2>Welcome to Weather Guesser!</h2>
-        <p>1. Click <strong>New City</strong> to choose a location.</p>
-        <p>2. Enter your temperature guess and submit.</p>
-        <p>3. Use <strong>Options</strong> to change units, region, and difficulty.</p>
+    <div id="onboarding-overlay">
+      <div id="onboarding-card">
+        <h2>Getting Started</h2>
+        <ol>
+          <li>
+            Select <strong>New City</strong> to pick a location.
+          </li>
+          <li>Enter your temperature guess and submit.</li>
+          <li>
+            Use <strong>Options</strong> to adjust units, region and difficulty.
+          </li>
+        </ol>
         <button id="onboarding-close" className="button" onClick={onClose}>
-          Got it!
+          Start Playing
         </button>
       </div>
     </div>

--- a/src/components/Onboarding.js
+++ b/src/components/Onboarding.js
@@ -1,0 +1,17 @@
+import "./Onboarding.css";
+
+export default function Onboarding({ onClose }) {
+  return (
+    <div id="onboarding-wrapper">
+      <div id="onboarding-box">
+        <h2>Welcome to Weather Guesser!</h2>
+        <p>1. Click <strong>New City</strong> to choose a location.</p>
+        <p>2. Enter your temperature guess and submit.</p>
+        <p>3. Use <strong>Options</strong> to change units, region, and difficulty.</p>
+        <button id="onboarding-close" className="button" onClick={onClose}>
+          Got it!
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add Onboarding component to show initial instructions
- show onboarding once for new visitors using localStorage
- style onboarding popup
- adjust header test for new component

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_683fb2f97fd88329953fc0f979f69e68