### PR TITLE
Render options inline

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -26,10 +26,6 @@ export default function App() {
     handleNewCityClick();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // Hide the options menu whenever the location or answer state updates
-  useEffect(() => {
-    document.querySelector("#options-wrapper").classList.add("hide");
-  }, [location, answer]);
 
   // Turns location data into a string for text display
   function cityString() {
@@ -78,10 +74,6 @@ export default function App() {
     );
   }
 
-  // toggle options screen when clicking the options button
-  function handleOptionsClick() {
-    document.querySelector("#options-wrapper").classList.toggle("hide");
-  }
 
   // update options when options form is changed
   function handleOptionsChange(e) {
@@ -175,10 +167,7 @@ export default function App() {
       <div className="App">
         <Header />
         <section id="main-content">
-          <NewCityAndOptions
-            onNewCityClick={handleNewCityClick}
-            onOptionsClick={handleOptionsClick}
-          />
+          <NewCityAndOptions onNewCityClick={handleNewCityClick} />
           <GuessForm
             currentCity={cityString()}
             onFormSubmit={handleAnswerSubmit}

--- a/src/components/MapAndOptions.css
+++ b/src/components/MapAndOptions.css
@@ -2,6 +2,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 20px;
 }
 #map-wrapper {
   display: block;
@@ -32,6 +33,14 @@ iframe {
   iframe {
     width: 420px;
     height: 400px;
+  }
+}
+
+@media only screen and (min-width: 800px) {
+  #map-and-options-wrapper {
+    flex-direction: row;
+    align-items: flex-start;
+    justify-content: center;
   }
 }
 

--- a/src/components/MapAndOptions.css
+++ b/src/components/MapAndOptions.css
@@ -1,6 +1,7 @@
 #map-and-options-wrapper {
-  display: inline-block;
-  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
 }
 #map-wrapper {
   display: block;

--- a/src/components/MapAndOptions.js
+++ b/src/components/MapAndOptions.js
@@ -19,8 +19,8 @@ export default function MapAndOptions({ location, onOptionsChange }) {
 
   return (
     <div id="map-and-options-wrapper">
-      <Options onOptionsChange={onOptionsChange} />
       <div id="map-wrapper">{loadMap()}</div>
+      <Options onOptionsChange={onOptionsChange} />
     </div>
   );
 }

--- a/src/components/NewCityAndOptions.css
+++ b/src/components/NewCityAndOptions.css
@@ -1,6 +1,6 @@
 #button-wrapper {
   display: flex;
-  justify-content: space-evenly;
+  justify-content: center;
   width: 60%;
   margin: auto;
 }

--- a/src/components/NewCityAndOptions.js
+++ b/src/components/NewCityAndOptions.js
@@ -1,10 +1,15 @@
 import "./NewCityAndOptions.css";
 
-export default function NewCityAndOptions({ onNewCityClick, onOptionsClick }) {
-    return (
-        <div id="button-wrapper">
-          <button id="new-city-button" className="button" onClick={onNewCityClick}>New City</button>
-          <button id="option-button" className="button" onClick={onOptionsClick}>Options</button>
-        </div>
-    );
+export default function NewCityAndOptions({ onNewCityClick }) {
+  return (
+    <div id="button-wrapper">
+      <button
+        id="new-city-button"
+        className="button"
+        onClick={onNewCityClick}
+      >
+        New City
+      </button>
+    </div>
+  );
 }

--- a/src/components/Options.css
+++ b/src/components/Options.css
@@ -4,7 +4,7 @@
   flex-direction: column;
   align-items: center;
   padding: 10px;
-  margin-bottom: 20px;
+  margin: 20px auto;
   background-color: rgba(230, 230, 230, 1);
   border: 2px solid black;
 }
@@ -17,7 +17,9 @@
   display: block;
   text-align: left;
   padding: 10px 0;
-  width: 100%;
+  width: 60%;
+  max-width: 300px;
+  margin: 0 auto;
 }
 .options-form p {
   margin-top: 10px;
@@ -39,5 +41,11 @@
 @media only screen and (max-width: 1000px) {
   #options-wrapper {
     font-size: 1em;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  .options-form {
+    width: 90%;
   }
 }

--- a/src/components/Options.css
+++ b/src/components/Options.css
@@ -2,14 +2,9 @@
   font-size: 0.7em;
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  z-index: 10;
+  padding: 10px;
+  margin-bottom: 20px;
   background-color: rgba(230, 230, 230, 1);
   border: 2px solid black;
 }
@@ -19,10 +14,10 @@
 }
 
 .options-form {
-  display: inline-block;
+  display: block;
   text-align: left;
   padding: 10px 0;
-  width: 44%;
+  width: 100%;
 }
 .options-form p {
   margin-top: 10px;
@@ -39,9 +34,6 @@
   background-color: white;
   padding: 3px;
   outline: none;
-}
-.hide {
-  display: none !important;
 }
 
 @media only screen and (max-width: 1000px) {

--- a/src/components/Options.js
+++ b/src/components/Options.js
@@ -2,7 +2,7 @@ import "./Options.css";
 
 export default function Options({ onOptionsChange }) {
   return (
-    <div id="options-wrapper" className="hide">
+    <div id="options-wrapper">
       <form className="options-form" onChange={onOptionsChange}>
         <p>
           <strong>Temperature:</strong>


### PR DESCRIPTION
## Summary
- show Options form inline rather than overlay
- drop Options button from NewCityAndOptions component
- update CSS for the new layout

## Testing
- `npm test --silent --yes` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fb2fef35483299021d5b01d3b706e