### PR TITLE
Add guess history feature

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -34,6 +34,21 @@
   color: rgb(201, 0, 0);
 }
 
+#map-history-wrapper {
+  display: flex;
+  gap: 20px;
+  justify-content: center;
+  align-items: flex-start;
+  margin-top: 20px;
+}
+
+@media only screen and (max-width: 600px) {
+  #map-history-wrapper {
+    flex-direction: column;
+    align-items: center;
+  }
+}
+
 .button {
   border-radius: 5px;
   background-color: rgb(43, 43, 241);

--- a/src/App.js
+++ b/src/App.js
@@ -200,11 +200,13 @@ export default function App() {
             difficultyString={difficultyString()}
           />
           <Answer answer={answer} weather={weather} isLoading={isLoading} />
-          <History history={history} onClear={handleClearHistory} />
-          <MapAndOptions
-            location={location}
-            onOptionsChange={handleOptionsChange}
-          />
+          <div id="map-history-wrapper">
+            <MapAndOptions
+              location={location}
+              onOptionsChange={handleOptionsChange}
+            />
+            <History history={history} onClear={handleClearHistory} />
+          </div>
         </section>
       </div>
       <Footer />

--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Footer from "./Footer";
 import NewCityAndOptions from "./components/NewCityAndOptions";
 import GuessForm from "./components/GuessForm";
 import MapAndOptions from "./components/MapAndOptions";
+import History from "./components/History";
 import { places } from "./modules/places";
 import FetchWrapper from "./modules/fetchwrapper";
 import Answer from "./components/Answer";
@@ -14,6 +15,7 @@ export default function App() {
   const [answer, setAnswer] = useState([0, ""]);
   const [weather, setWeather] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [history, setHistory] = useState([]);
   const [options, setOptions] = useState({
     temp: 1, // 1 - f, 0 - c
     tempDisplay: "℉",
@@ -99,6 +101,10 @@ export default function App() {
     }
   }
 
+  function handleClearHistory() {
+    setHistory([]);
+  }
+
   // Fetch weather data for the current city and update the state based on user guess
   function handleAnswerSubmit(e) {
     e.preventDefault();
@@ -134,13 +140,21 @@ export default function App() {
           };
 
           // Package up the data for the answer component
+          let resultText = "";
           if (guess > temp + tempRange()) {
             setAnswer([1, script]);
+            resultText = "Too high";
           } else if (guess < temp - tempRange()) {
             setAnswer([2, script]);
+            resultText = "Too low";
           } else {
             setAnswer([3, script]);
+            resultText = "Correct";
           }
+          setHistory((prev) => [
+            ...prev,
+            `Guess ${guess}${options.tempDisplay} for ${cityString()}: ${resultText} (actual ${temp}${options.tempDisplay})`,
+          ]);
 
           // Display current weather
           setWeather(
@@ -186,6 +200,7 @@ export default function App() {
             difficultyString={difficultyString()}
           />
           <Answer answer={answer} weather={weather} isLoading={isLoading} />
+          <History history={history} onClear={handleClearHistory} />
           <MapAndOptions
             location={location}
             onOptionsChange={handleOptionsChange}

--- a/src/components/History.css
+++ b/src/components/History.css
@@ -1,15 +1,20 @@
 #history-wrapper {
-  margin-top: 20px;
+  margin-top: 0;
+  width: 220px;
+  font-size: 0.9rem;
+  margin-left: 10px;
 }
 
 #history-controls {
   margin-bottom: 10px;
   display: flex;
   justify-content: center;
-  gap: 10px;
+  gap: 5px;
 }
 
 #history-list {
   list-style: none;
   padding: 0;
+  max-height: 300px;
+  overflow-y: auto;
 }

--- a/src/components/History.css
+++ b/src/components/History.css
@@ -1,0 +1,15 @@
+#history-wrapper {
+  margin-top: 20px;
+}
+
+#history-controls {
+  margin-bottom: 10px;
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+}
+
+#history-list {
+  list-style: none;
+  padding: 0;
+}

--- a/src/components/History.js
+++ b/src/components/History.js
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import "./History.css";
+
+export default function History({ history, onClear }) {
+  const [hidden, setHidden] = useState(false);
+
+  const toggleHidden = () => setHidden((prev) => !prev);
+
+  return (
+    <div id="history-wrapper">
+      <div id="history-controls">
+        <button className="button" onClick={toggleHidden}>
+          {hidden ? "Show History" : "Hide History"}
+        </button>
+        <button className="button" onClick={onClear}>Clear</button>
+      </div>
+      {!hidden && (
+        <ul id="history-list">
+          {history.map((entry, index) => (
+            <li key={index}>{entry}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new `History` component to show previous guesses
- store history in `App` state and record results after each submission
- provide a clear button and hide/show toggle for history

## Testing
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_683fb30fa82c83299419dc7569b00434