### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -5,6 +5,7 @@ import Footer from "./Footer";
 import NewCityAndOptions from "./components/NewCityAndOptions";
 import GuessForm from "./components/GuessForm";
 import MapAndOptions from "./components/MapAndOptions";
+import DarkModeToggle from "./components/DarkModeToggle";
 import { places } from "./modules/places";
 import FetchWrapper from "./modules/fetchwrapper";
 import Answer from "./components/Answer";
@@ -14,6 +15,10 @@ export default function App() {
   const [answer, setAnswer] = useState([0, ""]);
   const [weather, setWeather] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [darkMode, setDarkMode] = useState(() => {
+    const stored = localStorage.getItem("darkMode");
+    return stored ? JSON.parse(stored) : false;
+  });
   const [options, setOptions] = useState({
     temp: 1, // 1 - f, 0 - c
     tempDisplay: "℉",
@@ -30,6 +35,12 @@ export default function App() {
   useEffect(() => {
     document.querySelector("#options-wrapper").classList.add("hide");
   }, [location, answer]);
+
+  // Apply dark mode class and store preference
+  useEffect(() => {
+    document.body.classList.toggle("dark", darkMode);
+    localStorage.setItem("darkMode", JSON.stringify(darkMode));
+  }, [darkMode]);
 
   // Turns location data into a string for text display
   function cityString() {
@@ -97,6 +108,10 @@ export default function App() {
         tempDisplay: value ? "℉" : "℃",
       }));
     }
+  }
+
+  function handleDarkToggle() {
+    setDarkMode((prev) => !prev);
   }
 
   // Fetch weather data for the current city and update the state based on user guess
@@ -173,6 +188,7 @@ export default function App() {
   return (
     <>
       <div className="App">
+        <DarkModeToggle darkMode={darkMode} onToggle={handleDarkToggle} />
         <Header />
         <section id="main-content">
           <NewCityAndOptions

--- a/src/components/DarkModeToggle.css
+++ b/src/components/DarkModeToggle.css
@@ -1,0 +1,6 @@
+.dark-toggle {
+  position: fixed;
+  top: 10px;
+  right: 10px;
+  z-index: 1000;
+}

--- a/src/components/DarkModeToggle.js
+++ b/src/components/DarkModeToggle.js
@@ -1,0 +1,9 @@
+import "./DarkModeToggle.css";
+
+export default function DarkModeToggle({ darkMode, onToggle }) {
+  return (
+    <button className="dark-toggle button" onClick={onToggle}>
+      {darkMode ? "Light Mode" : "Dark Mode"}
+    </button>
+  );
+}

--- a/src/dark.css
+++ b/src/dark.css
@@ -1,0 +1,42 @@
+body.dark {
+  background-color: #000;
+  color: #f0f0f0;
+}
+
+body.dark #main-content {
+  background-image: none;
+  background-color: #222;
+  color: #f0f0f0;
+  border-color: #444;
+}
+
+body.dark footer {
+  background-color: #000;
+  border-top-color: #444;
+  color: #f0f0f0;
+}
+
+body.dark .button {
+  background-color: #444;
+  background-image: linear-gradient(#444, #222);
+  color: #fff;
+}
+
+body.dark #options-wrapper {
+  background-color: #333;
+  color: #fff;
+}
+
+body.dark #region {
+  background-color: #222;
+  color: #fff;
+}
+
+body.dark input#guess {
+  background-color: #333;
+  color: #fff;
+}
+
+body.dark iframe {
+  border-color: #444;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './normalize.css';
 import './index.css';
+import './dark.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 


### PR DESCRIPTION
## Summary
- create DarkModeToggle component
- manage light/dark preference in App
- add dark mode stylesheet and toggle button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fb30aeff88329ae357d059977403b