### PR TITLE
Add CrudCrud leaderboard service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
 
+## Daily Challenge Leaderboard
+
+The Daily Challenge mode stores scores in a temporary online database powered by [CrudCrud](https://crudcrud.com/). Each endpoint lasts for 24 hours and requires no sign up. Scores older than a day automatically disappear.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/App.js
+++ b/src/App.js
@@ -8,12 +8,14 @@ import MapAndOptions from "./components/MapAndOptions";
 import { places } from "./modules/places";
 import FetchWrapper from "./modules/fetchwrapper";
 import Answer from "./components/Answer";
+import DailyChallenge from "./components/DailyChallenge";
 
 export default function App() {
   const [location, setLocation] = useState(["Loading...", ""]);
   const [answer, setAnswer] = useState([0, ""]);
   const [weather, setWeather] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [dailyMode, setDailyMode] = useState(false);
   const [options, setOptions] = useState({
     temp: 1, // 1 - f, 0 - c
     tempDisplay: "℉",
@@ -173,24 +175,28 @@ export default function App() {
   return (
     <>
       <div className="App">
-        <Header />
-        <section id="main-content">
-          <NewCityAndOptions
-            onNewCityClick={handleNewCityClick}
-            onOptionsClick={handleOptionsClick}
-          />
-          <GuessForm
-            currentCity={cityString()}
-            onFormSubmit={handleAnswerSubmit}
-            tempDisplay={options.tempDisplay}
-            difficultyString={difficultyString()}
-          />
-          <Answer answer={answer} weather={weather} isLoading={isLoading} />
-          <MapAndOptions
-            location={location}
-            onOptionsChange={handleOptionsChange}
-          />
-        </section>
+        <Header onDailyClick={() => setDailyMode((prev) => !prev)} />
+        {dailyMode ? (
+          <DailyChallenge onExit={() => setDailyMode(false)} />
+        ) : (
+          <section id="main-content">
+            <NewCityAndOptions
+              onNewCityClick={handleNewCityClick}
+              onOptionsClick={handleOptionsClick}
+            />
+            <GuessForm
+              currentCity={cityString()}
+              onFormSubmit={handleAnswerSubmit}
+              tempDisplay={options.tempDisplay}
+              difficultyString={difficultyString()}
+            />
+            <Answer answer={answer} weather={weather} isLoading={isLoading} />
+            <MapAndOptions
+              location={location}
+              onOptionsChange={handleOptionsChange}
+            />
+          </section>
+        )}
       </div>
       <Footer />
     </>

--- a/src/Header.css
+++ b/src/Header.css
@@ -33,3 +33,13 @@ h1 {
     padding: 10px;
   }
 }
+
+.App-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+#daily-button {
+  margin-right: 20px;
+}

--- a/src/Header.js
+++ b/src/Header.js
@@ -1,9 +1,12 @@
-import './Header.css';
+import "./Header.css";
 
-export default function Header() {
+export default function Header({ onDailyClick }) {
   return (
     <header className="App-header">
-        <h1>Weather Guesser!</h1>
+      <h1>Weather Guesser!</h1>
+      <button id="daily-button" className="button" onClick={onDailyClick}>
+        Daily Challenge
+      </button>
     </header>
   );
 }

--- a/src/components/DailyChallenge.js
+++ b/src/components/DailyChallenge.js
@@ -1,0 +1,138 @@
+import { useState, useEffect } from "react";
+import FetchWrapper from "../modules/fetchwrapper";
+import { places } from "../modules/places";
+import Answer from "./Answer";
+import "./GuessForm.css";
+
+export default function DailyChallenge({ onExit }) {
+  const today = new Date().toISOString().slice(0, 10);
+
+  function getDailyLocation() {
+    let hash = 0;
+    for (let i = 0; i < today.length; i++) {
+      hash = (hash * 31 + today.charCodeAt(i)) % places.length;
+    }
+    return places[hash];
+  }
+
+  const [location] = useState(getDailyLocation());
+  const [answer, setAnswer] = useState([0, ""]);
+  const [weather, setWeather] = useState("");
+  const [scores, setScores] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const API = new FetchWrapper(
+      "https://crudcrud.com/api/9b79841d3e6b499fb25730d2bd5fff09/"
+    );
+    API.get("scores")
+      .then((data) => {
+        if (Array.isArray(data)) {
+          setScores(data.filter((s) => s.date === today));
+        } else {
+          setScores([]);
+        }
+      })
+      .catch(() => {
+        setScores([]);
+      });
+  }, [today]);
+
+  function handleSubmit(e) {
+    e.preventDefault();
+    setIsLoading(true);
+    const guess = parseInt(e.target.guess.value, 10);
+    const user = e.target.username.value || "anon";
+    const weatherAPI = new FetchWrapper(
+      "https://api.weatherapi.com/v1/current.json?key=72b4230dbcfc4df5b07205043212612&q="
+    );
+
+    weatherAPI
+      .get(location[0])
+      .then((data) => {
+        const tempF = Math.floor(data.current.temp_f);
+        const diff = Math.abs(tempF - guess);
+        const script = `Today's temp in ${location[0].replace(/_/g, " ")} is ${tempF}℉.`;
+
+        if (guess > tempF) {
+          setAnswer([1, script]);
+        } else if (guess < tempF) {
+          setAnswer([2, script]);
+        } else {
+          setAnswer([3, script]);
+        }
+
+        setWeather(
+          <>
+            <p>Current weather: {data.current.condition.text}</p>
+            <img src={data.current.condition.icon} alt={data.current.condition.text} />
+          </>
+        );
+
+        const API = new FetchWrapper(
+          "https://crudcrud.com/api/9b79841d3e6b499fb25730d2bd5fff09/"
+        );
+        API.post("scores", { date: today, user, diff })
+          .then(() => {
+            return API.get("scores");
+          })
+          .then((data) => {
+            if (Array.isArray(data)) {
+              setScores(data.filter((s) => s.date === today));
+            } else {
+              setScores([]);
+            }
+          })
+          .catch(() => {
+            // ignore errors
+          });
+      })
+      .catch(() => {
+        setAnswer([4, "The weather is unavailable right now :/"]);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }
+
+  return (
+    <div id="daily-challenge">
+      <h2>Daily Challenge</h2>
+      <p>
+        Guess the temperature in {location[0].replace(/_/g, " ")} ({location[1]})
+        .
+      </p>
+      <form id="daily-form" onSubmit={handleSubmit}>
+        <label htmlFor="username">Name</label>
+        <input type="text" id="username" name="username" required />
+        <label htmlFor="guess">Enter Guess ℉</label>
+        <input
+          type="number"
+          inputMode="numeric"
+          pattern="[0-9]*"
+          id="guess"
+          name="guess"
+          placeholder="0"
+          min="-150"
+          max="150"
+          required
+        />
+        <input type="submit" className="button" value="Submit" />
+      </form>
+      <Answer answer={answer} weather={weather} isLoading={isLoading} />
+      <h3>Leaderboard</h3>
+      <ol id="leaderboard">
+        {scores
+          .sort((a, b) => a.diff - b.diff)
+          .map((s, idx) => (
+            <li key={idx}>
+              {s.user}: {s.diff}° off
+            </li>
+          ))}
+      </ol>
+      <button className="button" onClick={onExit}>
+        Back to Game
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- integrate CrudCrud as the backend for storing daily challenge scores
- document how the leaderboard uses CrudCrud for 24‑hour storage

## Testing
- `npm test --silent`
- `CI=true npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fb1834cb083299e852d7685967e24