### PR TITLE
Add city selection feature

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -70,7 +70,7 @@ export default function App() {
   }
 
   // Loads a new city and updates all the necessary data
-  function handleNewCityClick() {
+  function handleNewCityClick(city) {
     setAnswer([0, ""]);
     setWeather("");
     setErrorMessage("");
@@ -89,9 +89,14 @@ export default function App() {
       }
     };
     const placesList = getPlaces();
-    setLocation(
-      () => placesList[Math.floor(Math.random() * placesList.length)]
-    );
+    if (city) {
+      const chosen = placesList.find((c) => c[0] === city);
+      if (chosen) {
+        setLocation(chosen);
+        return;
+      }
+    }
+    setLocation(() => placesList[Math.floor(Math.random() * placesList.length)]);
   }
 
   // toggle options screen when clicking the options button

--- a/src/components/CitySelector.css
+++ b/src/components/CitySelector.css
@@ -1,0 +1,17 @@
+#city-selector-wrapper {
+  display: flex;
+  align-items: center;
+}
+
+#city-selector {
+  border: 1px solid rgb(0, 0, 199);
+  border-radius: 4px;
+  padding: 4px;
+  min-width: 150px;
+  text-align: center;
+}
+
+#city-selector:focus {
+  border: 2px solid rgb(0, 0, 199);
+  outline: none;
+}

--- a/src/components/CitySelector.js
+++ b/src/components/CitySelector.js
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { places } from "../modules/places";
+import "./CitySelector.css";
+
+export default function CitySelector({ onSelect }) {
+  const [value, setValue] = useState("");
+  const cityNames = places.map((p) => p[0]);
+
+  function handleChange(e) {
+    const city = e.target.value;
+    setValue(city);
+    if (onSelect) {
+      onSelect(city);
+    }
+  }
+
+  return (
+    <div id="city-selector-wrapper">
+      <input
+        id="city-selector"
+        list="city-list"
+        value={value}
+        onChange={handleChange}
+        placeholder="Select city"
+      />
+      <datalist id="city-list">
+        {cityNames.map((c) => (
+          <option key={c} value={c}>
+            {c.replace(/_/g, " ")}
+          </option>
+        ))}
+      </datalist>
+    </div>
+  );
+}

--- a/src/components/NewCityAndOptions.css
+++ b/src/components/NewCityAndOptions.css
@@ -5,8 +5,15 @@
   margin: auto;
 }
 
+#city-selector {
+  margin: 0 10px;
+}
+
 @media only screen and (max-width: 600px) {
   #button-wrapper {
     width: 100%;
+  }
+  #city-selector {
+    margin-top: 10px;
   }
 }

--- a/src/components/NewCityAndOptions.js
+++ b/src/components/NewCityAndOptions.js
@@ -1,10 +1,24 @@
 import "./NewCityAndOptions.css";
+import CitySelector from "./CitySelector";
 
 export default function NewCityAndOptions({ onNewCityClick, onOptionsClick }) {
-    return (
-        <div id="button-wrapper">
-          <button id="new-city-button" className="button" onClick={onNewCityClick}>New City</button>
-          <button id="option-button" className="button" onClick={onOptionsClick}>Options</button>
-        </div>
-    );
+  return (
+    <div id="button-wrapper">
+      <button
+        id="new-city-button"
+        className="button"
+        onClick={() => onNewCityClick()}
+      >
+        New City
+      </button>
+      <CitySelector onSelect={onNewCityClick} />
+      <button
+        id="option-button"
+        className="button"
+        onClick={onOptionsClick}
+      >
+        Options
+      </button>
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- create a `CitySelector` component to pick a city
- integrate city selector into new city options panel
- update styling for the new selector
- allow `handleNewCityClick` to optionally take a city name

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fc6308f5c8329a00cdc31c03af2e1