### PR TITLE
Add hint feature

### DIFF
--- a/src/components/GuessForm.css
+++ b/src/components/GuessForm.css
@@ -48,6 +48,14 @@
     padding: 6px;
 }
 
+#hint-button {
+  margin-left: 10px;
+  padding: 7px;
+}
+#hint-button:focus {
+  padding: 6px;
+}
+
 @media only screen and (max-width: 600px) {
   #weather-guesser input {
     min-width: 60px;

--- a/src/components/GuessForm.js
+++ b/src/components/GuessForm.js
@@ -6,6 +6,8 @@ export default function GuessForm({
   onFormSubmit,
   tempDisplay,
   difficultyString,
+  onHintClick,
+  hintsLeft,
 }) {
   const [submitted, setSubmitted] = useState(false);
 
@@ -44,6 +46,15 @@ export default function GuessForm({
           required
         />
         <input type="submit" id="submit" className="button" value="Submit" />
+        <button
+          type="button"
+          id="hint-button"
+          className="button"
+          onClick={onHintClick}
+          disabled={hintsLeft <= 0}
+        >
+          Hint ({hintsLeft})
+        </button>
       </form>
       <p>
         <sub>You win if your guess is {difficultyString}</sub>


### PR DESCRIPTION
## Summary
- track hints in `App` and reset on new cities
- provide hint fetching logic comparing guess against actual temp
- add a button in `GuessForm` to request hints
- style the hint button

## Testing
- `npm install`
- `npx react-scripts test --watchAll=false --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_683fc6321fd483299be5b8f582622eb2