### PR TITLE
Highlight new leaderboard entries

### DIFF
--- a/src/components/DailyChallenge.css
+++ b/src/components/DailyChallenge.css
@@ -1,0 +1,14 @@
+.score-added {
+  animation: highlight-fade 0.5s ease-out;
+}
+
+@keyframes highlight-fade {
+  from {
+    background-color: yellow;
+    opacity: 0;
+  }
+  to {
+    background-color: transparent;
+    opacity: 1;
+  }
+}

--- a/src/components/DailyChallenge.js
+++ b/src/components/DailyChallenge.js
@@ -1,8 +1,9 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import FetchWrapper from "../modules/fetchwrapper";
 import { places } from "../modules/places";
 import Answer from "./Answer";
 import "./GuessForm.css";
+import "./DailyChallenge.css";
 
 export default function DailyChallenge({ onExit }) {
   const today = new Date().toISOString().slice(0, 10);
@@ -20,6 +21,7 @@ export default function DailyChallenge({ onExit }) {
   const [weather, setWeather] = useState("");
   const [scores, setScores] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
+  const scoreRefs = useRef([]);
 
   useEffect(() => {
     const API = new FetchWrapper(
@@ -37,6 +39,14 @@ export default function DailyChallenge({ onExit }) {
         setScores([]);
       });
   }, [today]);
+
+  useEffect(() => {
+    scoreRefs.current.forEach((item) => item && item.classList.add("score-added"));
+    const t = setTimeout(() => {
+      scoreRefs.current.forEach((item) => item && item.classList.remove("score-added"));
+    }, 500);
+    return () => clearTimeout(t);
+  }, [scores]);
 
   function handleSubmit(e) {
     e.preventDefault();
@@ -125,7 +135,7 @@ export default function DailyChallenge({ onExit }) {
         {scores
           .sort((a, b) => a.diff - b.diff)
           .map((s, idx) => (
-            <li key={idx}>
+            <li key={idx} ref={(el) => (scoreRefs.current[idx] = el)}>
               {s.user}: {s.diff}° off
             </li>
           ))}


### PR DESCRIPTION
## Summary
- add new DailyChallenge.css for leaderboard animations
- animate leaderboard entries whenever scores update

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_683fc63547908329999f738e883a04ee